### PR TITLE
Add a callback functionality to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ Add ```ensure redemrp_progressbars``` in server.cfg
 ## 2. How to start
 
 ```
- exports.redemrp_progressbars:DisplayProgressBar(5000, "Cooking...")
+ exports.redemrp_progressbars:DisplayProgressBar(5000, "Cooking...", function()
+  --do stuff
+ )
 ```
 * this resource has a build-in wait so you don't need to add ``` Wait(5000)``` after use the progress bar
+* callbacks are optional
 
 ![alt text](https://i.imgur.com/s1PiTUN.png)
 

--- a/client.lua
+++ b/client.lua
@@ -9,7 +9,7 @@ function RequestDict(dicts)
     end
 end
 
-exports('DisplayProgressBar', function(time, desciption)
+exports('DisplayProgressBar', function(time, desciption, cb)
     RequestDict(TextureDicts)
     local timer = (time / 100)
     local DisplayElemet = 0
@@ -23,6 +23,13 @@ exports('DisplayProgressBar', function(time, desciption)
             Text(0.5001, 0.93, 0.28, desciption, {255, 255, 255}, false, true)
         end
     end)
+    
+    if cb then
+        Citizen.CreateThread(function()
+            cb()
+        end)
+    end
+
     while DisplayElemet < 100 do
         DisplayElemet = DisplayElemet + 1
         Wait(timer)


### PR DESCRIPTION
It allows to do stuff without waiting for the progress bar to finish.